### PR TITLE
Keep only 1 space after commas and none before

### DIFF
--- a/lib/formatValues.js
+++ b/lib/formatValues.js
@@ -1,7 +1,8 @@
 function formatProperties (decl) {
 
   decl.value = decl.value.trim().replace(/\s+/g, ' ')
-  decl.value = decl.value.replace(/,/g, ', ')
+  // Remove spaces before commas and keep only one space after.
+  decl.value = decl.value.replace(/(\s+)?,(\s)*/g, ', ')
 
   if (decl.important) {
     decl._important = " !important"

--- a/test/fixtures/values.css
+++ b/test/fixtures/values.css
@@ -1,4 +1,6 @@
 .class {
   background: linear-gradient(to bottom right,white,hsla(0,0%,100%,.8));
   border: solid 1px rgba(0,0,0,.3);
+  font-family: Arial  ,  sans-serif;
+  color: rgba(0, 0, 0, 1);
 }

--- a/test/fixtures/values.out.css
+++ b/test/fixtures/values.out.css
@@ -1,4 +1,6 @@
 .class {
   background: linear-gradient(to bottom right, white, hsla(0, 0%, 100%, .8));
   border: 1px solid rgba(0, 0, 0, .3);
+  font-family: Arial, sans-serif;
+  color: rgba(0, 0, 0, 1);
 }


### PR DESCRIPTION
If a value had already a space after a comma, `cssfmt` added a second
space.

input:
```
font: Arial, sans-serif;
```

output:
```
font: Arial,  sans-serif;
```

This commit fixes the regex in `lib/formatValues.js` by keeping only
one space after commas and removing the others.