### PR TITLE
Read file from stdin

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,6 +3,7 @@
 var fs = require('fs')
 var path = require('path')
 var child_process = require('child_process')
+var stdin = require('stdin')
 var pkg = require('../package.json')
 var cssfmt = require('../')
 
@@ -36,8 +37,8 @@ if (argv.h) {
 }
 
 if (argv._[0]) {
-  var input  = argv._[0]
-  var output  = argv._[1] || argv._[0]
+  var input = argv._[0]
+  var output = argv._[1] || argv._[0]
 
   var css = fs.readFileSync(input, 'utf-8')
   var formatted = cssfmt.process(css)
@@ -50,7 +51,11 @@ if (argv._[0]) {
       if (err) throw err
     })
   }
-
+} else {
+  stdin(function (css) {
+    var formatted = cssfmt.process(css)
+    process.stdout.write(formatted)
+  })
 }
 
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CSSfmt is a tool that automatically formats CSS source code, inspired by Gofmt.",
   "main": "index.js",
   "scripts": {
-    "test": "tape test"
+    "test": "tape test/*.js"
   },
   "bin": {
     "cssfmt": "bin/cli.js"
@@ -26,6 +26,7 @@
     "minimist": "^1.1.2",
     "postcss": "^4.1.16",
     "sort-border-values": "^0.1.1",
+    "stdin": "0.0.1",
     "tmp": "0.0.26"
   },
   "devDependencies": {

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,97 @@
+var spawn = require('child_process').spawn
+var path = require('path')
+var fs = require('fs')
+var tape = require('tape')
+
+tape('cli stdin', function (t) {
+  spawnCssfmt([], readFixture('values.css'), function (err, output) {
+    if (err) {
+      throw err
+    }
+
+    var expected = readFixture('values.out.css')
+    t.equal(output, expected)
+    t.end()
+  })
+})
+
+tape('cli input file option', function (t) {
+  var tempFile = fixturesPath('values.copy.css')
+  fs.writeFileSync(tempFile, readFixture('values.css'), 'utf-8')
+
+  spawnCssfmt([tempFile], null, function (err) {
+    if (err) {
+      throw err
+    }
+
+    var output = fs.readFileSync(tempFile, 'utf-8')
+    fs.unlinkSync(tempFile)
+
+    var expected = readFixture('values.out.css')
+    t.equal(output, expected)
+
+    t.end()
+  })
+})
+
+tape('cli output file option', function (t) {
+  var tempFile = fixturesPath('values.copy.css')
+
+  spawnCssfmt([fixturesPath('values.css'), tempFile], null, function(err) {
+    if (err) {
+      throw err
+    }
+
+    t.ok(fs.existsSync(tempFile), 'output file created')
+
+    var output = fs.readFileSync(tempFile, 'utf-8')
+    fs.unlinkSync(tempFile)
+
+    var expected = readFixture('values.out.css')
+    t.equal(output, expected)
+
+    t.end()
+  })
+})
+
+
+function fixturesPath (filename) {
+  return path.join(__dirname, 'fixtures', filename)
+}
+
+function readFixture (filename) {
+  return fs.readFileSync(fixturesPath(filename), 'utf-8')
+}
+
+function spawnCssfmt (options, input, callback) {
+  var args = [path.join(__dirname, '../bin/cli.js')]
+  args = args.concat(options)
+
+  var childprocess = spawn('node', args, {
+    stdio: ['pipe', 'pipe', 'pipe']
+  })
+  var output = ''
+  var error = ''
+
+  childprocess.stdout.on('data', function (data) {
+    output += data.toString()
+  })
+
+  childprocess.stderr.on('data', function (data) {
+    error += data.toString()
+  })
+
+  childprocess.on('exit', function() {
+    if (error) {
+      callback(new Error(error))
+      return
+    }
+
+    callback(null, output)
+  })
+
+  if (input) {
+    childprocess.stdin.write(input)
+    childprocess.stdin.end()
+  }
+}


### PR DESCRIPTION
In the CLI, if we don't specify a file to read, it reads the content from stdin.

This will help to build editors' plugin (see #7).
For instance, this allows us to run the command `:%!cssfmt` in Vim to format the current buffer.

Let me know if I've followed your JS coding style and if the tests I've added cover enough cases.