### PR TITLE
Fix atrule for comments format

### DIFF
--- a/lib/formatComments.js
+++ b/lib/formatComments.js
@@ -10,7 +10,7 @@ function formatComments (root) {
       commentBefore = ''
     } else {
       if (parentType === 'atrule') {
-        if (comment.parent.first === atrule) {
+        if (comment.parent.first === comment) {
           commentBefore = '\n' + getIndent(comment)
         } else {
           commentBefore = '\n\n' + getIndent(comment)

--- a/test/fixtures/comment.css
+++ b/test/fixtures/comment.css
@@ -10,3 +10,18 @@
 
 .foo{color:red
 }
+
+
+/*
+  at rule
+ */
+@media only screen {
+  /* inner at rule comment */
+  .foo { display: none; }
+  /*
+   * another comment
+   */
+.bar {
+  color:yellow;
+}
+}

--- a/test/fixtures/comment.out.css
+++ b/test/fixtures/comment.out.css
@@ -9,3 +9,20 @@
 .foo {
   color: red;
 }
+
+/*
+  at rule
+ */
+@media only screen {
+  /* inner at rule comment */
+  .foo {
+    display: none;
+  }
+
+  /*
+   * another comment
+   */
+  .bar {
+    color: yellow;
+  }
+}


### PR DESCRIPTION
We checked `comment.parent.first` against `atrule`, which was always
undefined, instead of `comment`.
Add test to cover this fix.