### PR TITLE
WIP: Fix media indent

### DIFF
--- a/lib/formatAtRules.js
+++ b/lib/formatAtRules.js
@@ -6,7 +6,6 @@ function formatAtRules (root) {
   root.walkAtRules(function (atrule, index) {
     var parentType = atrule.parent.type
     var atruleBefore
-    var atruleAfter
 
     var hasComment = false
     var prev = atrule.prev()
@@ -14,19 +13,15 @@ function formatAtRules (root) {
       hasComment = true
     }
 
-
     if (index === 0 && parentType === 'root') {
       atruleBefore = ''
     } else {
-      if (parentType === 'atrule') {
+      if (parentType === 'atrule' || parentType === 'rule') {
         if (atrule.parent.first === atrule) {
           atruleBefore = '\n' + getIndent(atrule)
         } else {
           atruleBefore = '\n\n' + getIndent(atrule)
         }
-      }
-      if (parentType === 'rule') {
-        atruleBefore = '\n\n' + getIndent(atrule)
       }
 
       if (parentType === 'root') {
@@ -41,7 +36,6 @@ function formatAtRules (root) {
         atruleBefore = '\n' + getIndent(atrule)
       }
     }
-
 
     atrule.params = formatAtRuleParams(atrule)
 

--- a/test/fixtures/nested-atrule.css
+++ b/test/fixtures/nested-atrule.css
@@ -4,3 +4,8 @@
 {position: absolute
     }}
 }
+.foo {
+
+  @media (max-width: 1000px) { display: none;
+  }
+}

--- a/test/fixtures/nested-atrule.out.css
+++ b/test/fixtures/nested-atrule.out.css
@@ -5,3 +5,9 @@
     }
   }
 }
+
+.foo {
+  @media (max-width: 1000px) {
+    display: none;
+  }
+}


### PR DESCRIPTION
*WIP: do not merge*

I've started to fix the indent for nested `@media` declaration:

Current output
```
.foo {

  @media (max-width: 1000px) {
  display: none;
  }
}
```

Expected:
```
.foo {
  @media (max-width: 1000px) {
    display: none;
  }
}
```

So far I have fixed the `@media` indent but not the properties indent.
WIP output:
```
.foo {
  @media (max-width: 1000px) {
  display: none;
  }
}
```

I've looked at `getNestedRulesNum` in `lib/util.js` but apparently it returns `parent.type === 'root'` for `display: none;`.

Am I looking at the right place? Do you have any clue on how to fix this indent issue?
Do you think it's a postcss issue?

Thanks.