### PR TITLE
Find the nearest .editorconfig

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,12 +1,13 @@
 var fs = require('fs')
 var repeatString = require('repeat-string')
 var editorconfigIndent = require('editorconfig-indent')
+var findConfig = require('find-config')
 
 var editorconfig
 var ec
 
 try {
-  editorconfig = fs.readFileSync(process.cwd() + '/.editorconfig', 'utf-8')
+  editorconfig = fs.readFileSync(findConfig('.editorconfig'), 'utf-8')
   ec = editorconfigIndent(editorconfig)
 } catch (e) {}
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "editorconfig-indent": "^0.1.0",
+    "find-config": "0.3.0",
     "minimist": "^1.1.2",
     "postcss": "^5.0.6",
     "postcss-scss": "^0.1.0",


### PR DESCRIPTION
`cssfmt` is not necessarily executed at the same level as the `.editorconfig` file. Therefore we need to find the nearest config file.

See kewah/vim-cssfmt#1