### PR TITLE
Fix undefined indentWidth variable

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -4,6 +4,7 @@ var editorconfigIndent = require('editorconfig-indent')
 
 var editorconfig
 var ec
+var indentWidth = '  '
 
 try {
   editorconfig = fs.readFileSync(process.cwd() + '/.editorconfig', 'utf-8')
@@ -17,9 +18,6 @@ if (ec) {
   else if (ec.indentStyle === 'space' || ec.indentStyle === null) {
     indentWidth = repeatString(' ', ec.indentSize)
   }
-}
-else {
-  indentWidth = '  '
 }
 
 


### PR DESCRIPTION
When executing cssfmt in the cli, I got an error because indentWidth wasn't declared.