### PR TITLE
Sass @include fixes

### DIFF
--- a/lib/formatAtRuleParams.js
+++ b/lib/formatAtRuleParams.js
@@ -1,5 +1,5 @@
 function formatAtRuleParams (atrule) {
-  var params = atrule.params
+  var params = atrule.raws.params ? atrule.raws.params.raw : atrule.params
   var atName = atrule.name
   var atTypes = [
     'media',
@@ -16,7 +16,6 @@ function formatAtRuleParams (atrule) {
    if (atTypes.indexOf(atName) > -1) {
     params = params.replace(/\s*:\s*/g, ': ')
     params = params.replace(/\s*,\s*/g, ', ')
-    params = params.replace(/\s+/g, ' ')
     if (params.match(/^\(\s*/)) {
       params = params.replace(/^\(\s*/g, '(')
     } else if (atName === 'function' || atName === 'if' || atName === 'else') {
@@ -26,6 +25,9 @@ function formatAtRuleParams (atrule) {
     }
     params = params.replace(/\s*\)/g, ')')
     params = params.replace(/\)\s*{/g, ') ')
+    params = params.replace(/\/\*/g, ' $&')
+    params = params.replace(/\*\//g, '$& ')
+    params = params.replace(/\s+/g, ' ')
   }
 
   if (atName === 'return' || atName === 'if' || atName === 'else') {

--- a/lib/formatAtRules.js
+++ b/lib/formatAtRules.js
@@ -7,6 +7,19 @@ var hasDecls = require('./hasDecls')
 function formatAtRules (root) {
   root.walkAtRules(function (atrule, index) {
     var parentType = atrule.parent.type
+    var sassAtBlockTypes = [
+      'mixin',
+      'function',
+      'for',
+      'each',
+      'while',
+      'if',
+      'else'
+    ]
+    var prev = atrule.prev();
+    var isPrevRule = prev && prev.type === 'rule'
+    var isPrevSassAtBlock = prev && sassAtBlockTypes.indexOf(prev.name) > -1
+    var hasLineBreaksBefore = /[\n]{2}/.test(atrule.raws.before)
     var atruleBefore
 
     var hasComment = false
@@ -109,11 +122,17 @@ function formatAtRules (root) {
     if (atrule.name === 'include') {
       atrule.params = atrule.params.replace(/(^[\w|-]+)\s*\(/, "$1(")
       atrule.params = atrule.params.replace(/\)\s*{/g, ') ')
-      atrule.raws.before = '\n' + getIndent(atrule)
+      if (!hasLineBreaksBefore) {
+        atrule.raws.before = '\n' + getIndent(atrule)
+      }
       atrule.raws.between = ''
 
       if (atrule.parent.type === 'root') {
-        atrule.raws.before = '\n\n' + getIndent(atrule)
+
+        if (hasLineBreaksBefore || isPrevRule || isPrevSassAtBlock) {
+          atrule.raws.before = '\n\n' + getIndent(atrule)
+        }
+
         atrule.raws.between = ' '
 
         if (index === 0) {

--- a/test/fixtures/sass-include-2.css
+++ b/test/fixtures/sass-include-2.css
@@ -1,3 +1,28 @@
 @include font-face("Pictos", "../fonts/pictos-web");
 
 @include transform(translateZ(0) translateY(20px));
+@include transform(translateZ(0) /* translateY(20px) */ translateX(0));
+@include transform(translateZ(0)/* translateY(20px) */translateX(0));
+
+
+
+@include transform(translateZ(0), /* translateY(20px) */translateX(0));
+@include transform(  translateZ(0),   /** translateY(20px) **/   translateX(0)  );
+div {
+  color: blue;
+  @extend %class;
+
+  @include mixin();
+  @include mixin-2();
+
+
+  @include mixin-3();
+}
+@include mixin();
+@function func(  $value   ) {@return $value;}
+@include mixin();
+@mixin mix( ) { color:blue}
+@include mixin();
+@if true { color: red} @else {color:blue}
+@include mixin();
+@include apply-to-ie6-only {#logo {background-image: url(/logo.gif);}}

--- a/test/fixtures/sass-include-2.out.css
+++ b/test/fixtures/sass-include-2.out.css
@@ -1,3 +1,45 @@
 @include font-face("Pictos", "../fonts/pictos-web");
 
 @include transform(translateZ(0) translateY(20px));
+@include transform(translateZ(0) /* translateY(20px) */ translateX(0));
+@include transform(translateZ(0) /* translateY(20px) */ translateX(0));
+
+@include transform(translateZ(0), /* translateY(20px) */ translateX(0));
+@include transform(translateZ(0), /** translateY(20px) **/ translateX(0));
+
+div {
+  color: blue;
+  @extend %class;
+
+  @include mixin();
+  @include mixin-2();
+
+  @include mixin-3();
+}
+
+@include mixin();
+
+@function func($value) {
+  @return $value;
+}
+
+@include mixin();
+
+@mixin mix() {
+  color: blue;
+}
+
+@include mixin();
+
+@if true {
+  color: red;
+} @else {
+  color: blue;
+}
+
+@include mixin();
+@include apply-to-ie6-only {
+  #logo {
+    background-image: url(/logo.gif);
+  }
+}


### PR DESCRIPTION
- Make sure that comments inside @include parameters are not removed
- Format comments inside @include parameters
- Don’t add extra empty lines to @include calls that are next to each
other
- Format multiple empty lines between @include calls to one empty line
- Add extra empty lines to @include calls that are between rules or
Sass blocks