### PR TITLE
Make sure that named colors are not matched from a middle of a string

### DIFF
--- a/lib/formatColors.js
+++ b/lib/formatColors.js
@@ -1,5 +1,5 @@
 var cssColors = require('css-color-list')
-var namedColorsRegex = new RegExp(cssColors().join('|'), 'ig')
+var namedColorsRegex = new RegExp('(^|\s+)(' + cssColors().join('|') + ')(?=\$|\s+)', 'ig')
 var hslRegex = /hsla?\(\s*\d{1,3}\s*,\s*\d{1,3}%\s*,\s*\d{1,3}%\s*(,\s*[\d\.]+)?\s*\)/ig
 var hexRegex = /#[a-f0-9]{3}([a-f0-9]{3})?/ig
 var rgbRegex = /rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}\s*(,\s*[\d\.]+)?\s*\)/ig

--- a/test/fixtures/lowercase.css
+++ b/test/fixtures/lowercase.css
@@ -19,6 +19,8 @@ $myVar7: linear-gradient(to right, RGBA(0,0,0,0.5), RGB(255,255,255));
   TRANSFORM: TRANSLATE3D(0,0,0);
   TRANSFORM: MATRIX(1,1,1,1);
   transform: translateY(0) $myVar;
+  animation: textAnimation 0.1s;
+  animation: tAnimation 0.1s;
 }
 
 .class-2 {

--- a/test/fixtures/lowercase.out.css
+++ b/test/fixtures/lowercase.out.css
@@ -18,6 +18,8 @@ $myVar7: linear-gradient(to right, rgba(0, 0, 0, 0.5), rgb(255, 255, 255));
   transform: translate3d(0, 0, 0);
   transform: matrix(1, 1, 1, 1);
   transform: translateY(0) $myVar;
+  animation: textAnimation 0.1s;
+  animation: tAnimation 0.1s;
 }
 
 .class-2 {


### PR DESCRIPTION
Currently named colors regex matches `tAn` from `animation: textAnimation 0.1s;`.

P.S.
I also have another bugfix coming for Sass math formatting.