### PR TITLE
Don't replace spaces inside strings such as content property

### DIFF
--- a/lib/formatValues.js
+++ b/lib/formatValues.js
@@ -4,13 +4,16 @@ var formatColors = require('./formatColors')
 function formatProperties (decl) {
   var isDataUrl = (/data:.+\/(.+);base64,(.*)/).test(decl.value)
   var isVarNotation = (/var\s*\(.*\)/).test(decl.value)
+  var isString = (/^("|').+("|')$/).test(decl.value)
   var isSassUnaryInsideParentheses = (/\(\s?(-|\+)\$\w+\s?\)/).test(decl.value)
 
   if (decl.raws.value) {
     decl.raws.value.raw = decl.raws.value.raw.trim()
   }
 
-  decl.value = decl.value.trim().replace(/\s+/g, ' ')
+  if (!isString) {
+    decl.value = decl.value.trim().replace(/\s+/g, ' ')
+  }
 
   if (!isDataUrl) {
     // Remove spaces before commas and keep only one space after.

--- a/test/fixtures/content.css
+++ b/test/fixtures/content.css
@@ -1,0 +1,2 @@
+div {content: "  test";   content:'  test';
+}

--- a/test/fixtures/content.out.css
+++ b/test/fixtures/content.out.css
@@ -1,0 +1,4 @@
+div {
+  content: "  test";
+  content: '  test';
+}

--- a/test/index.js
+++ b/test/index.js
@@ -39,6 +39,7 @@ test('at-media')
 test('data-url')
 test('color-hex-lowercase')
 test('lowercase')
+test('content')
 
 // for future syntaxes
 test('cssnext-example')


### PR DESCRIPTION
Currently CSSfmt trims whitespace inside string values:

```css
div {
  content: "  test";
}
```
Gets changed to:

```css
div {
  content: " test";
}
```
With one space removed.

