### PR TITLE
Make sure that Internet Explorer CSS hacks are not removed

### DIFF
--- a/lib/formatDecls.js
+++ b/lib/formatDecls.js
@@ -8,9 +8,16 @@ function formatDecls (rule) {
   if (hasDecls(rule)) {
     rule.walkDecls(function (decl) {
       var isCustomProp = /^--/.test(decl.prop)
+      var isIEHack = (/(\*|_)$/).test(decl.raws.before)
+
       if (decl.prop && !isCustomProp) {
         decl.prop = decl.prop.toLowerCase()
       }
+
+      if (isIEHack) {
+        decl.prop = decl.raws.before.replace(/\n/g, '') + decl.prop
+      }
+
       var more = config.indentWidth
       decl.raws.before = '\n' + getIndent(rule) + more
       decl.raws.between = ': '

--- a/test/fixtures/ie-hacks.css
+++ b/test/fixtures/ie-hacks.css
@@ -1,0 +1,9 @@
+* html p {font-size: 5em; }
+.class {
+*zoom: 1;_width: 200px;
++color:red;
+*+color:red;
+color:red\9;
+color:red\0;
+color:red\9\0;
+}

--- a/test/fixtures/ie-hacks.out.css
+++ b/test/fixtures/ie-hacks.out.css
@@ -1,0 +1,13 @@
+* html p {
+  font-size: 5em;
+}
+
+.class {
+  *zoom: 1;
+  _width: 200px;
+  +color: red;
+  *+color: red;
+  color: red\9;
+  color: red\0;
+  color: red\9\0;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -40,6 +40,7 @@ test('data-url')
 test('color-hex-lowercase')
 test('lowercase')
 test('content')
+test('ie-hacks')
 
 // for future syntaxes
 test('cssnext-example')


### PR DESCRIPTION
There are many CSS hacks that work for legacy Internet Explorer versions (http://codemug.com/html/css-hacks-for-ie6ie7ie8ie9-and-ie10/).

Currently CSSfmt turns this 

```css
.class {
  *zoom: 1;
  _width: 200px;
}
```

Into this:

```css
.class {
  zoom: 1;
  width: 200px;
}
```