### PR TITLE
Don't format nth-child params

### DIFF
--- a/lib/formatSelectors.js
+++ b/lib/formatSelectors.js
@@ -5,11 +5,15 @@ function formatSelectors (rule) {
 
   var tmp = []
   rule.selectors.forEach(function (selector, i) {
-    if (checkSelector(selector)) {
-      tmp.push(selector.replace(/\s*([+~>])\s*/g, "$1 "))
+    if (isFirstLetterCombinator(selector)) {
+      selector = selector.replace(/\s*([+~>])\s*/g, "$1 ")
     } else {
-      tmp.push(selector.replace(/\s*([+~>])\s*/g, " $1 "))
+      // don't add extra spaces to :nth-child(5n+1) etc.
+      if (!hasPlusInsideParens(selector)) {
+        selector = selector.replace(/\s*([+~>])\s*/g, " $1 ")
+      }
     }
+    tmp.push(selector)
   })
 
   rule.selector = tmp.join(separator)
@@ -17,11 +21,12 @@ function formatSelectors (rule) {
   return rule
 }
 
-/*
- * Check if the first letter of the selector is a combinator keyword
- */
-function checkSelector (selector) {
-  return selector.match(/^[+~>]/) ? true : false
+function hasPlusInsideParens (selector) {
+  return (/\(.+\+.+\)/).test(selector)
+}
+
+function isFirstLetterCombinator (selector) {
+  return (/^[+~>]/).test(selector)
 }
 
 

--- a/test/fixtures/nested-2.css
+++ b/test/fixtures/nested-2.css
@@ -1,5 +1,8 @@
 .btn {&:hover {
     color: red;
   }&:active {
-color:blue;}
+color:blue;}  &:nth-child(5n+1) {
+    color:blue;
+  }
+  &:nth-child(-n+3) { color: green;}
   }

--- a/test/fixtures/nested-2.out.css
+++ b/test/fixtures/nested-2.out.css
@@ -6,4 +6,12 @@
   &:active {
     color: blue;
   }
+
+  &:nth-child(5n+1) {
+    color: blue;
+  }
+
+  &:nth-child(-n+3) {
+    color: green;
+  }
 }


### PR DESCRIPTION
Currently CSSfmt is formatting:

```css
&:nth-child(5n+1) {
  color: blue;
}
```
to this:

```css
&:nth-child(5n + 1) {
  color: blue;
}
```