### PR TITLE
Math operator fixes

### DIFF
--- a/lib/formatSassVariables.js
+++ b/lib/formatSassVariables.js
@@ -4,18 +4,23 @@ var formatColors = require('./formatColors')
 function formatSassVariables (root) {
   root.walkDecls(function (decl) {
     if (isSassVariable(decl)) {
+      var isFunctionCall = (/\w+\(.+\)/).test(decl.value)
+
       // format math operators before `$` or `(`.
       decl.value = decl.value.trim().replace(/(?!^)[+\-*/%](?=\$|\()/g, ' $& ')
-      // don't format minus sign (-) before a number
-      // because we don't know if it is
-      // part of a Sass variable name (e.g. $my-var-1-2).
-      decl.value = decl.value.trim().replace(/[+\*/%](?=\d+)/g, ' $& ')
 
-      var hasVariableWithDash = (/\$\w+-\w+/).test(decl.value)
+      if (!isFunctionCall) {
+        // don't format minus sign (-) before a number
+        // because we don't know if it is
+        // part of a Sass variable name (e.g. $my-var-1-2).
+        decl.value = decl.value.trim().replace(/[+\*/%](?=\d+)/g, ' $& ')
 
-      if (!hasVariableWithDash) {
-        // format minus sign before number if safe
-        decl.value = decl.value.trim().replace(/(?!^)-(?=\d+)/g, ' $& ')
+        var hasVariableWithDash = (/\$\w+-\w+/).test(decl.value)
+
+        if (!hasVariableWithDash) {
+          // format minus sign before number if safe
+          decl.value = decl.value.trim().replace(/(?!^)-(?=\d+)/g, ' $& ')
+        }
       }
 
       var isDataUrl = (/data:.+\/(.+);base64,(.*)/).test(decl.value)

--- a/lib/formatValues.js
+++ b/lib/formatValues.js
@@ -5,7 +5,7 @@ function formatProperties (decl) {
   var isDataUrl = (/data:.+\/(.+);base64,(.*)/).test(decl.value)
   var isVarNotation = (/var\s*\(.*\)/).test(decl.value)
   var isString = (/^("|').+("|')$/).test(decl.value)
-  var isSassUnaryInsideParentheses = (/\(\s?(-|\+)\$\w+\s?\)/).test(decl.value)
+  var isFunctionCall = (/\w+\(.+\)/).test(decl.value)
 
   if (decl.raws.value) {
     decl.raws.value.raw = decl.raws.value.raw.trim()
@@ -25,8 +25,8 @@ function formatProperties (decl) {
     decl.value = decl.value.replace(/\s*\)/g, ')')
   }
 
-  if (!isSassUnaryInsideParentheses) {
-    decl.value = decl.value.trim().replace(/[+\-*/%](?=\$|\()/g, ' $& ')
+  if (!isFunctionCall) {
+    decl.value = decl.value.trim().replace(/(?!^)[+\-*/%](?=\$|\(|\d)/g, ' $& ')
   }
 
   decl.value = decl.value.replace(/\(\s*/g, '(')

--- a/test/fixtures/sass-math.css
+++ b/test/fixtures/sass-math.css
@@ -4,11 +4,15 @@ $var : -((1*5%2)-(2+2-1));
 $my-var:$var-1+$var-2;$var3:-100deg;
 $var4:-$var3;
 $var5  :    +$var3;
+$height:   em(240/2);
+      $easing :  cubic-bezier(.35,0,.765,-0.120);
 div {
   width:((100%-($numPerRow*$margin))/$numPerRow);
 transform: translateX(-$pos);   transform: translateX( +$pos );
 transform: translateX($pos -3);
 transform: translateX(   3-1);
+font-size:percentage(12/16);
+margin-top: -($height/2);
 }@function myFn() {
 @return -((1*5%2)-(2+2-1));
 }

--- a/test/fixtures/sass-math.out.css
+++ b/test/fixtures/sass-math.out.css
@@ -6,6 +6,8 @@ $my-var: $var-1 + $var-2;
 $var3: -100deg;
 $var4: -$var3;
 $var5: +$var3;
+$height: em(240/2);
+$easing: cubic-bezier(.35, 0, .765, -0.120);
 
 div {
   width: ((100% - ($numPerRow * $margin)) / $numPerRow);
@@ -13,6 +15,8 @@ div {
   transform: translateX(+$pos);
   transform: translateX($pos -3);
   transform: translateX(3-1);
+  font-size: percentage(12/16);
+  margin-top: -($height / 2);
 }
 
 @function myFn() {


### PR DESCRIPTION
- Don’t format math operators inside function calls
- Don’t format math operators at the beginning of a string, but add
spaces before a number: `/[+\-*/%](?=\$|\()/g` => `/(?!^)[+\-*/%](?=\$|\(|\d)/g`

With this input:

```scss
$height: em(240/2);
$easing: cubic-bezier(.35, 0, .765, -0.120);

div {
  margin-top: -($height/2);
}
```

CSSfmt output before:

```scss
$height: em(240 / 2);
$easing: cubic-bezier(.35, 0, .765, - 0.120);

div {
  margin-top: - ($height/2);
}
```

and after fixes:

```scss
$height: em(240/2);
$easing: cubic-bezier(.35, 0, .765, -0.120);

div {
  margin-top: -($height / 2);
}
```