### PR TITLE
Trim spaces from IE hacks

### DIFF
--- a/lib/formatDecls.js
+++ b/lib/formatDecls.js
@@ -15,7 +15,7 @@ function formatDecls (rule) {
       }
 
       if (isIEHack) {
-        decl.prop = decl.raws.before.replace(/\n/g, '') + decl.prop
+        decl.prop = decl.raws.before.trim().replace(/\n/g, '') + decl.prop
       }
 
       var more = config.indentWidth

--- a/test/fixtures/sass-mixin.css
+++ b/test/fixtures/sass-mixin.css
@@ -1,3 +1,12 @@
 @mixin   horizontal-line    (   $border:   1px dashed #ccc,  $padding:10px   )  {
     border-bottom:$border;
 }
+@mixin clearfix {
+  *zoom: 1;
+  &:before,&:after {
+    display: table;
+    content: "";
+  }  &:after {
+    clear: both;
+  }
+}

--- a/test/fixtures/sass-mixin.out.css
+++ b/test/fixtures/sass-mixin.out.css
@@ -1,3 +1,17 @@
 @mixin horizontal-line($border: 1px dashed #ccc, $padding: 10px) {
   border-bottom: $border;
 }
+
+@mixin clearfix {
+  *zoom: 1;
+
+  &:before,
+  &:after {
+    display: table;
+    content: "";
+  }
+
+  &:after {
+    clear: both;
+  }
+}


### PR DESCRIPTION
This change fixes a bug where indentation would not be correct because spaces where not trimmed from IE hacks (e.g. `*zoom: 1;`).

```scss
@mixin clearfix {
    *zoom: 1;

  &:before,
  &:after {
    display: table;
    content: "";
  }

  &:after {
    clear: both;
  }
}
```