### PR TITLE
Fix formatting bug when using multiple direct child selectors

### DIFF
--- a/lib/formatSelectors.js
+++ b/lib/formatSelectors.js
@@ -5,14 +5,11 @@ function formatSelectors (rule) {
 
   var tmp = []
   rule.selectors.forEach(function (selector, i) {
-    if (isFirstLetterCombinator(selector)) {
-      selector = selector.replace(/\s*([+~>])\s*/g, "$1 ")
-    } else {
-      // don't add extra spaces to :nth-child(5n+1) etc.
-      if (!hasPlusInsideParens(selector)) {
-        selector = selector.replace(/\s*([+~>])\s*/g, " $1 ")
-      }
+    // don't add extra spaces to :nth-child(5n+1) etc.
+    if (!hasPlusInsideParens(selector)) {
+      selector = selector.replace(/\s*([+~>])\s*/g, " $1 ")
     }
+    selector = selector.replace(/^\s*([+~>])\s*/g, "$1 ")
     tmp.push(selector)
   })
 
@@ -24,10 +21,5 @@ function formatSelectors (rule) {
 function hasPlusInsideParens (selector) {
   return (/\(.+\+.+\)/).test(selector)
 }
-
-function isFirstLetterCombinator (selector) {
-  return (/^[+~>]/).test(selector)
-}
-
 
 module.exports = formatSelectors

--- a/test/fixtures/nested-2.css
+++ b/test/fixtures/nested-2.css
@@ -5,4 +5,10 @@ color:blue;}  &:nth-child(5n+1) {
     color:blue;
   }
   &:nth-child(-n+3) { color: green;}
+> li > a {   color: red}  >li>li {
+  color: blue;
+  }
+> p + p {
+    color: green;
+  }
   }

--- a/test/fixtures/nested-2.out.css
+++ b/test/fixtures/nested-2.out.css
@@ -14,4 +14,16 @@
   &:nth-child(-n+3) {
     color: green;
   }
+
+  > li > a {
+    color: red;
+  }
+
+  > li > li {
+    color: blue;
+  }
+
+  > p + p {
+    color: green;
+  }
 }


### PR DESCRIPTION
Fix a formatting bug where CSSfmt is formatting this:

```css
> li > a {
}
```
...to this:

```css
> li> a {
}
```