### PR TITLE
Don't add newlines to Sass inline comments that are next to atrules

### DIFF
--- a/lib/formatComments.js
+++ b/lib/formatComments.js
@@ -7,12 +7,13 @@ function formatComments (root) {
     var isInline = comment.raws.inline === true
     var isPrevInline = comment.prev() && comment.prev().raws.inline
     var isPrevDecl = comment.prev() && comment.prev().type === 'decl'
+    var isPrevAtRule = comment.prev() && comment.prev().type === 'atrule'
     var hasLineBreakBefore = /[\n]/.test(comment.raws.before)
     var commentBefore
 
     if (index === 0 && parentType === 'root') {
       commentBefore = ''
-    } else if (isPrevDecl && !hasLineBreakBefore) {
+    } else if ((isPrevDecl || isPrevAtRule) && !hasLineBreakBefore) {
       commentBefore = ' '
     } else {
       if (parentType === 'atrule') {

--- a/test/fixtures/sass-comment.css
+++ b/test/fixtures/sass-comment.css
@@ -20,3 +20,6 @@ color: red; }
   //bar
   margin:auto;
 }
+
+@include something; // comment
+@extend .something;// comment

--- a/test/fixtures/sass-comment.out.css
+++ b/test/fixtures/sass-comment.out.css
@@ -16,3 +16,6 @@
   //bar
   margin: auto;
 }
+
+@include something; // comment
+@extend .something; // comment


### PR DESCRIPTION
Currently CSSfmt adds newlines to inline comments that are next to `@include` or `@extend`. This PR adds a check for atrules for the inline comment fix from https://github.com/morishitter/cssfmt/pull/57.